### PR TITLE
fix(auth): avoid IndexError when parsing WWW-Authenticate

### DIFF
--- a/winrm_decrypt.py
+++ b/winrm_decrypt.py
@@ -228,8 +228,15 @@ def main():
                 auth_token = base64.b64decode(b64_token)
 
             elif hasattr(cap.http, 'www_authenticate'):
-                b64_token = cap.http.www_authenticate.split(' ')[1]
-                auth_token = base64.b64decode(b64_token)
+                parts = cap.http.www_authenticate.split(' ')
+                if len(parts) > 1:
+                    b64_token = parts[1]
+                    try:
+                        auth_token = base64.b64decode(b64_token)
+                    except Exception:
+                        continue
+                else:
+                    continue
 
             context = None
             if auth_token:


### PR DESCRIPTION
Previously, the code assumed that cap.http.www_authenticate always contained both the 'Negotiate' keyword and a base64 NTLM token, and directly accessed split(' ')[1]. This caused IndexError when the header only contained 'Negotiate'.

Now, the header string is split into parts and checked for length  before accessing the token. If no token is present, the frame is skipped with 'continue', preventing crashes during parsing.