### PR TITLE
Fixed Error - unsupported hash type md4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyshark==0.4.3
 cryptography==3.3.2
-pycrytodome
+pycryptodome

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyshark==0.4.3
 cryptography==3.3.2
+pycrytodome

--- a/winrm_decrypt.py
+++ b/winrm_decrypt.py
@@ -27,6 +27,7 @@ import binascii
 import sys
 import struct
 import xml.dom.minidom
+from Crypto.Hash import MD4
 
 from cryptography.hazmat.primitives.ciphers import (
     algorithms,
@@ -146,7 +147,9 @@ def hmac_md5(key, data):
 
 
 def md4(m):
-    return hashlib.new('md4', m).digest()
+    h = MD4.new()
+    h.update(m)
+    return h.digest()
 
 
 def md5(m):


### PR DESCRIPTION
to fix this error `ValueError: unsupported hash type md4` 
used MD4 hash from pycryptodome library